### PR TITLE
Added support for sending validators data

### DIFF
--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -17,3 +17,4 @@ tsconfig.tsbuildinfo
 lcov.info
 tenderly.yaml
 docs/
+.history/

--- a/contracts/src/Gateway.sol
+++ b/contracts/src/Gateway.sol
@@ -2,10 +2,12 @@
 // SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
 pragma solidity 0.8.25;
 
+import {console2} from "forge-std/console2.sol";
 import {MerkleProof} from "openzeppelin/utils/cryptography/MerkleProof.sol";
 import {Verification} from "./Verification.sol";
 
 import {Assets} from "./Assets.sol";
+import {Validators} from "./Validators.sol";
 import {AgentExecutor} from "./AgentExecutor.sol";
 import {Agent} from "./Agent.sol";
 import {
@@ -465,6 +467,11 @@ contract Gateway is IGateway, IInitializable, IUpgradable {
         _submitOutbound(ticket);
     }
 
+    function sendValidatorsData(bytes calldata data, ParaID destinationChain) external payable {
+        Ticket memory ticket = Validators.encodeValidatorsData(data, destinationChain);
+        _submitOutbound(ticket);
+    }
+
     // @dev Get token address by tokenID
     function tokenAddressOf(bytes32 tokenID) external view returns (address) {
         return Assets.tokenAddressOf(tokenID);
@@ -528,8 +535,8 @@ contract Gateway is IGateway, IInitializable, IUpgradable {
 
         // Destination fee always in DOT
         uint256 fee = _calculateFee(ticket.costs);
-
-        // Ensure the user has enough funds for this message to be accepted
+        console2.log("Fee: ", fee);
+        // // Ensure the user has enough funds for this message to be accepted
         if (msg.value < fee) {
             revert FeePaymentToLow();
         }

--- a/contracts/src/Gateway.sol
+++ b/contracts/src/Gateway.sol
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
 pragma solidity 0.8.25;
 
-import {console2} from "forge-std/console2.sol";
 import {MerkleProof} from "openzeppelin/utils/cryptography/MerkleProof.sol";
 import {Verification} from "./Verification.sol";
 
@@ -535,8 +534,8 @@ contract Gateway is IGateway, IInitializable, IUpgradable {
 
         // Destination fee always in DOT
         uint256 fee = _calculateFee(ticket.costs);
-        console2.log("Fee: ", fee);
-        // // Ensure the user has enough funds for this message to be accepted
+
+        // Ensure the user has enough funds for this message to be accepted
         if (msg.value < fee) {
             revert FeePaymentToLow();
         }

--- a/contracts/src/Gateway.sol
+++ b/contracts/src/Gateway.sol
@@ -6,7 +6,7 @@ import {MerkleProof} from "openzeppelin/utils/cryptography/MerkleProof.sol";
 import {Verification} from "./Verification.sol";
 
 import {Assets} from "./Assets.sol";
-import {Validators} from "./Validators.sol";
+import {Operators} from "./Operators.sol";
 import {AgentExecutor} from "./AgentExecutor.sol";
 import {Agent} from "./Agent.sol";
 import {
@@ -466,8 +466,8 @@ contract Gateway is IGateway, IInitializable, IUpgradable {
         _submitOutbound(ticket);
     }
 
-    function sendValidatorsData(bytes calldata data, ParaID destinationChain) external payable {
-        Ticket memory ticket = Validators.encodeValidatorsData(data, destinationChain);
+    function sendOperatorsData(bytes calldata data, ParaID destinationChain) external payable {
+        Ticket memory ticket = Operators.encodeOperatorsData(data, destinationChain);
         _submitOutbound(ticket);
     }
 

--- a/contracts/src/Operators.sol
+++ b/contracts/src/Operators.sol
@@ -20,27 +20,32 @@ import {SubstrateTypes} from "./SubstrateTypes.sol";
 import {MultiAddress, Ticket, Costs, ParaID} from "./Types.sol";
 import {IGateway} from "./interfaces/IGateway.sol";
 
-library Validators {
-    error Validators__UnsupportedValidatorsLength();
-    error Validators__ValidatorsLengthTooLong();
+library Operators {
+    error Operators__UnsupportedOperatorsLength();
+    error Operators__OperatorsLengthTooLong();
+    error Operators__OperatorsKeysCannotBeEmpty();
 
     uint8 private constant VALIDATOR_KEY_HEX_LENGTH = 32 * 2;
+    uint16 private constant MAX_OPERATORS = 1000;
 
-    function encodeValidatorsData(bytes calldata validatorsKeys, ParaID dest) internal returns (Ticket memory ticket) {
-        if (validatorsKeys.length % VALIDATOR_KEY_HEX_LENGTH != 0) {
-            revert Validators__UnsupportedValidatorsLength();
+    function encodeOperatorsData(bytes calldata operatorsKeys, ParaID dest) internal returns (Ticket memory ticket) {
+        if (operatorsKeys.length == 0) {
+            revert Operators__OperatorsKeysCannotBeEmpty();
         }
-        uint256 validatorsKeysLength = validatorsKeys.length / VALIDATOR_KEY_HEX_LENGTH;
+        if (operatorsKeys.length % VALIDATOR_KEY_HEX_LENGTH != 0) {
+            revert Operators__UnsupportedOperatorsLength();
+        }
+        uint256 validatorsKeysLength = operatorsKeys.length / VALIDATOR_KEY_HEX_LENGTH;
 
-        if (validatorsKeysLength > 1000) {
-            revert Validators__ValidatorsLengthTooLong();
+        if (validatorsKeysLength > MAX_OPERATORS) {
+            revert Operators__OperatorsLengthTooLong();
         }
 
         ticket.dest = dest;
-        // For now mock it to 0
+        //TODO For now mock it to 0
         ticket.costs = Costs(0, 0);
 
-        ticket.payload = SubstrateTypes.EncodedValidatorsData(validatorsKeys, uint32(validatorsKeysLength));
-        emit IGateway.ValidatorsDataCreated(validatorsKeysLength, ticket.payload);
+        ticket.payload = SubstrateTypes.EncodedOperatorsData(operatorsKeys, uint32(validatorsKeysLength));
+        emit IGateway.OperatorsDataCreated(validatorsKeysLength, ticket.payload);
     }
 }

--- a/contracts/src/SubstrateTypes.sol
+++ b/contracts/src/SubstrateTypes.sol
@@ -197,11 +197,11 @@ library SubstrateTypes {
         );
     }
 
-    function EncodedValidatorsData(bytes calldata validatorsKeys, uint32 validatorsCount)
+    function EncodedOperatorsData(bytes calldata operatorsKeys, uint32 operatorsCount)
         internal
         pure
         returns (bytes memory)
     {
-        return bytes.concat(bytes4(0x70150038), ScaleCodec.encodeCompactU32(validatorsCount), validatorsKeys);
+        return bytes.concat(bytes4(0x70150038), ScaleCodec.encodeCompactU32(operatorsCount), operatorsKeys);
     }
 }

--- a/contracts/src/SubstrateTypes.sol
+++ b/contracts/src/SubstrateTypes.sol
@@ -9,7 +9,7 @@ import {ParaID} from "./Types.sol";
  * @title SCALE encoders for common Substrate types
  */
 library SubstrateTypes {
-    error UnsupportedCompactEncoding();
+    error SubstrateTypes__UnsupportedCompactEncoding();
 
     /**
      * @dev Encodes `MultiAddress::Id`: https://crates.parity.io/sp_runtime/enum.MultiAddress.html#variant.Id
@@ -195,5 +195,13 @@ library SubstrateTypes {
             ScaleCodec.encodeU128(amount),
             ScaleCodec.encodeU128(xcmFee)
         );
+    }
+
+    function EncodedValidatorsData(bytes calldata validatorsKeys, uint32 validatorsCount)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bytes.concat(bytes4(0x70150038), ScaleCodec.encodeCompactU32(validatorsCount), validatorsKeys);
     }
 }

--- a/contracts/src/Validators.sol
+++ b/contracts/src/Validators.sol
@@ -1,0 +1,46 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
+pragma solidity 0.8.25;
+
+import {BeefyClient} from "./BeefyClient.sol";
+import {ScaleCodec} from "./utils/ScaleCodec.sol";
+import {SubstrateTypes} from "./SubstrateTypes.sol";
+import {MultiAddress, Ticket, Costs, ParaID} from "./Types.sol";
+import {IGateway} from "./interfaces/IGateway.sol";
+
+library Validators {
+    error Validators__UnsupportedValidatorsLength();
+    error Validators__ValidatorsLengthTooLong();
+
+    uint8 private constant VALIDATOR_KEY_HEX_LENGTH = 32 * 2;
+
+    function encodeValidatorsData(bytes calldata validatorsKeys, ParaID dest) internal returns (Ticket memory ticket) {
+        if (validatorsKeys.length % VALIDATOR_KEY_HEX_LENGTH != 0) {
+            revert Validators__UnsupportedValidatorsLength();
+        }
+        uint256 validatorsKeysLength = validatorsKeys.length / VALIDATOR_KEY_HEX_LENGTH;
+
+        if (validatorsKeysLength > 1000) {
+            revert Validators__ValidatorsLengthTooLong();
+        }
+
+        ticket.dest = dest;
+        // For now mock it to 0
+        ticket.costs = Costs(0, 0);
+
+        ticket.payload = SubstrateTypes.EncodedValidatorsData(validatorsKeys, uint32(validatorsKeysLength));
+        emit IGateway.ValidatorsDataCreated(validatorsKeysLength, ticket.payload);
+    }
+}

--- a/contracts/src/interfaces/IGateway.sol
+++ b/contracts/src/interfaces/IGateway.sol
@@ -113,4 +113,8 @@ interface IGateway {
         uint128 destinationFee,
         uint128 amount
     ) external payable;
+
+    event ValidatorsDataCreated(uint256 indexed validatorsCount, bytes payload);
+
+    function sendValidatorsData(bytes calldata data, ParaID destinationChain) external payable;
 }

--- a/contracts/src/interfaces/IGateway.sol
+++ b/contracts/src/interfaces/IGateway.sol
@@ -114,7 +114,7 @@ interface IGateway {
         uint128 amount
     ) external payable;
 
-    event ValidatorsDataCreated(uint256 indexed validatorsCount, bytes payload);
+    event OperatorsDataCreated(uint256 indexed validatorsCount, bytes payload);
 
-    function sendValidatorsData(bytes calldata data, ParaID destinationChain) external payable;
+    function sendOperatorsData(bytes calldata data, ParaID destinationChain) external payable;
 }

--- a/contracts/test/Gateway.t.sol
+++ b/contracts/test/Gateway.t.sol
@@ -19,7 +19,7 @@ import {AgentExecutor} from "../src/AgentExecutor.sol";
 import {Agent} from "../src/Agent.sol";
 import {Verification} from "../src/Verification.sol";
 import {Assets} from "../src/Assets.sol";
-import {Validators} from "../src/Validators.sol";
+import {Operators} from "../src/Operators.sol";
 
 import {SubstrateTypes} from "./../src/SubstrateTypes.sol";
 import {MultiAddress} from "../src/MultiAddress.sol";
@@ -1025,7 +1025,7 @@ contract GatewayTest is Test {
     bytes private constant WRONG_LENGTH_VALIDATORS_DATA =
         "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe228eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a4";
 
-    function createLongValidatorsData() public pure returns (bytes memory) {
+    function createLongOperatorsData() public pure returns (bytes memory) {
         bytes memory result = new bytes(VALIDATORS_DATA.length * 1000);
 
         for (uint256 i = 0; i < 33; i++) {
@@ -1037,7 +1037,7 @@ contract GatewayTest is Test {
         return result;
     }
 
-    function testSendValidatorsData() public {
+    function testSendOperatorsData() public {
         // Create mock agent and paraID
         ParaID paraID = ParaID.wrap(1);
         bytes32 agentID = keccak256("1");
@@ -1052,10 +1052,10 @@ contract GatewayTest is Test {
         vm.expectEmit(true, false, false, false);
         emit IGateway.OutboundMessageAccepted(paraID.into(), 1, messageID, FINAL_VALIDATORS_PAYLOAD);
 
-        IGateway(address(gateway)).sendValidatorsData{value: 1 ether}(VALIDATORS_DATA, paraID);
+        IGateway(address(gateway)).sendOperatorsData{value: 1 ether}(VALIDATORS_DATA, paraID);
     }
 
-    function testShouldNotSendValidatorsDataBecauseValidatorsNotMultipleOf32() public {
+    function testShouldNotSendOperatorsDataBecauseOperatorsNotMultipleOf32() public {
         // Create mock agent and paraID
         ParaID paraID = ParaID.wrap(1);
         bytes32 agentID = keccak256("1");
@@ -1066,11 +1066,11 @@ contract GatewayTest is Test {
             CreateChannelParams({channelID: paraID.into(), agentID: agentID, mode: OperatingMode.Normal});
 
         MockGateway(address(gateway)).createChannelPublic(abi.encode(params));
-        vm.expectRevert(Validators.Validators__UnsupportedValidatorsLength.selector);
-        IGateway(address(gateway)).sendValidatorsData{value: 1 ether}(WRONG_LENGTH_VALIDATORS_DATA, paraID);
+        vm.expectRevert(Operators.Operators__UnsupportedOperatorsLength.selector);
+        IGateway(address(gateway)).sendOperatorsData{value: 1 ether}(WRONG_LENGTH_VALIDATORS_DATA, paraID);
     }
 
-    function testShouldNotSendValidatorsDataBecauseValidatorsTooLong() public {
+    function testShouldNotSendOperatorsDataBecauseOperatorsTooLong() public {
         // Create mock agent and paraID
         ParaID paraID = ParaID.wrap(1);
         bytes32 agentID = keccak256("1");
@@ -1081,9 +1081,9 @@ contract GatewayTest is Test {
             CreateChannelParams({channelID: paraID.into(), agentID: agentID, mode: OperatingMode.Normal});
 
         MockGateway(address(gateway)).createChannelPublic(abi.encode(params));
-        bytes memory longValidatorsData = createLongValidatorsData();
+        bytes memory longOperatorsData = createLongOperatorsData();
 
-        vm.expectRevert(Validators.Validators__ValidatorsLengthTooLong.selector);
-        IGateway(address(gateway)).sendValidatorsData{value: 1 ether}(longValidatorsData, paraID);
+        vm.expectRevert(Operators.Operators__OperatorsLengthTooLong.selector);
+        IGateway(address(gateway)).sendOperatorsData{value: 1 ether}(longOperatorsData, paraID);
     }
 }


### PR DESCRIPTION
Added support for sending validators data. It expects a bytes string of validators. It encodes it in a polkadot supported type